### PR TITLE
Fix "Shoot Up Into Sky" by reset height to 1.2m

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ crashlytics-build.properties
 .utmp/
 
 .DS_Store
+TempAssembly.dll

--- a/Assets/Scenes/BasicSceneAR.unity
+++ b/Assets/Scenes/BasicSceneAR.unity
@@ -8664,6 +8664,10 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 3162837999221295853}
+    - targetCorrespondingSourceObject: {fileID: 2218496723442559054, guid: d6878e1999eb4b44a9f5a263af86c185,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 9027064624634110102}
     - targetCorrespondingSourceObject: {fileID: 657184243640684908, guid: d6878e1999eb4b44a9f5a263af86c185,
         type: 3}
       insertIndex: -1
@@ -8769,6 +8773,19 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 9027064624634110089}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &9027064624634110102
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9027064624634110090}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e69981d55eaca4fbe805f8ba78524fd7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_MinMaxHeight: {x: 1, y: 2}
 --- !u!114 &9205069178121381598
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/VRMPAssets/Scripts/Helpers/CharacterHeightResetter.cs
+++ b/Assets/VRMPAssets/Scripts/Helpers/CharacterHeightResetter.cs
@@ -6,6 +6,7 @@ namespace XRMultiplayer
     public class CharacterHeightResetter : MonoBehaviour
     {
         [SerializeField] Vector2 m_MinMaxHeight = new Vector2(1.0f, 2.0f);
+        [SerializeField] float m_ResetHeight = 1.2f;
         TeleportationProvider m_TeleportationProvider;
 
         private void Start()
@@ -25,7 +26,7 @@ namespace XRMultiplayer
         void ResetHeight()
         {
             Vector3 newPosition = transform.position;  // Get current position
-            newPosition.y = Mathf.Clamp(newPosition.y, m_MinMaxHeight.x, m_MinMaxHeight.y);        // Only modify Y value (height)
+            newPosition.y = m_ResetHeight;        // Only modify Y value (height)
 
             TeleportRequest teleportRequest = new()
             {

--- a/Assets/VRMPAssets/Scripts/Helpers/CharacterHeightResetter.cs
+++ b/Assets/VRMPAssets/Scripts/Helpers/CharacterHeightResetter.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+using UnityEngine.XR.Interaction.Toolkit.Locomotion.Teleportation;
+
+namespace XRMultiplayer
+{
+    public class CharacterHeightResetter : MonoBehaviour
+    {
+        [SerializeField] Vector2 m_MinMaxHeight = new Vector2(1.0f, 2.0f);
+        TeleportationProvider m_TeleportationProvider;
+
+        private void Start()
+        {
+            m_TeleportationProvider = GetComponentInChildren<TeleportationProvider>();
+        }
+
+        void Update()
+        {
+            float currentHeight = transform.position.y;
+            if (currentHeight < m_MinMaxHeight.x || currentHeight > m_MinMaxHeight.y)
+            {
+                ResetHeight();
+            }
+        }
+
+        void ResetHeight()
+        {
+            Vector3 newPosition = transform.position;  // Get current position
+            newPosition.y = Mathf.Clamp(newPosition.y, m_MinMaxHeight.x, m_MinMaxHeight.y);        // Only modify Y value (height)
+
+            TeleportRequest teleportRequest = new()
+            {
+                destinationPosition = newPosition,
+                destinationRotation = transform.rotation  // Keep current rotation
+            };
+
+            if (!m_TeleportationProvider.QueueTeleportRequest(teleportRequest))
+            {
+                Utils.LogWarning("Failed to queue teleport request");
+            }
+        }
+    }
+} 

--- a/Assets/VRMPAssets/Scripts/Helpers/CharacterHeightResetter.cs.meta
+++ b/Assets/VRMPAssets/Scripts/Helpers/CharacterHeightResetter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e69981d55eaca4fbe805f8ba78524fd7


### PR DESCRIPTION
Related Issues:
#5 
#4 

## Reason of bug:
CharacterReseter.cs on XR Origin was disabled because it was written for VR app and we don't want the x-axis and z-axis to be modified. but we still need a CharacterHeightReseter.cs to avoid invalid height

## Test:
In unity play mode, when I manually set XR Origin y-axis to 5, it instantly go back to 2
<img width="353" alt="image" src="https://github.com/user-attachments/assets/7246d134-76a3-4f4e-8f02-903b3601de98" />
