### PR TITLE
Implement PlayerPrefs-Based Name & Avatar Persistence (#9)

### DIFF
--- a/Assets/VRMPAssets/Scripts/Network/NetworkPlayer/XRINetworkPlayer.cs
+++ b/Assets/VRMPAssets/Scripts/Network/NetworkPlayer/XRINetworkPlayer.cs
@@ -273,7 +273,7 @@ namespace XRMultiplayer
                     {
                         // Get spawn transform for Player 2's XROrigin
                         var (xrPosition, xrRotation) = XRINetworkGameManager.Instance.GetSpawnTransform();
-                        
+
                         // Position and rotate the XROrigin
                         m_XROrigin.transform.position = xrPosition;
                         m_XROrigin.transform.rotation = xrRotation;
@@ -283,7 +283,8 @@ namespace XRMultiplayer
                 {
                     Utils.Log("No XR Rig Available", 1);
                 }
-
+                
+                XRINetworkGameManager.LocalPlayerName.Value = PlayerPrefs.GetString("UserName", "Player");
                 SetupLocalPlayer();
             }
             CompleteSetup();

--- a/Assets/VRMPAssets/Scripts/Player/PlayerAppearanceMenu.cs
+++ b/Assets/VRMPAssets/Scripts/Player/PlayerAppearanceMenu.cs
@@ -20,14 +20,17 @@ namespace XRMultiplayer
 
         // PlayerPrefs keys
         private const string USER_NAME_KEY = "UserName";
-        // Example key if an avatar dropdown is added later:
-        private const string AVATAR_INDEX_KEY = "AvatarIndex";
-
         void Awake()
         {
-            string savedName = PlayerPrefs.GetString(USER_NAME_KEY, "Player");
+            XRINetworkGameManager.LocalPlayerName.Value = PlayerPrefs.GetString(USER_NAME_KEY, "Player");
 
-            XRINetworkGameManager.LocalPlayerName.Value = savedName;
+            // Loading the saved color 
+            float r = PlayerPrefs.GetFloat("UserColor_R", 1f);
+            float g = PlayerPrefs.GetFloat("UserColor_G", 1f);
+            float b = PlayerPrefs.GetFloat("UserColor_B", 1f);
+            float a = PlayerPrefs.GetFloat("UserColor_A", 1f);
+            Color savedColor = new Color(r, g, b, a);
+            XRINetworkGameManager.LocalPlayerColor.Value = savedColor;
 
             XRINetworkGameManager.LocalPlayerName.Subscribe(SetPlayerName);
             XRINetworkGameManager.LocalPlayerColor.Subscribe(SetPlayerColor);
@@ -51,9 +54,8 @@ namespace XRMultiplayer
         /// </summary>
         public void SubmitNewPlayerName(string text)
         {
-            
-            XRINetworkGameManager.LocalPlayerName.Value = text;
 
+            XRINetworkGameManager.LocalPlayerName.Value = text;
             PlayerPrefs.SetString(USER_NAME_KEY, text);
             PlayerPrefs.Save();
         }
@@ -67,14 +69,20 @@ namespace XRMultiplayer
             List<Color> availableColors = new(m_PlayerColors);
             if (availableColors.Remove(XRINetworkGameManager.LocalPlayerColor.Value))
             {
-                XRINetworkGameManager.LocalPlayerColor.Value 
+                XRINetworkGameManager.LocalPlayerColor.Value
                  = availableColors[Random.Range(0, availableColors.Count)];
             }
             else
             {
-                XRINetworkGameManager.LocalPlayerColor.Value 
-                    = m_PlayerColors[Random.Range(0, m_PlayerColors.Length)];
+                XRINetworkGameManager.LocalPlayerColor.Value = m_PlayerColors[Random.Range(0, m_PlayerColors.Length)];
             }
+            // Code for saving the new color
+            Color newColor = XRINetworkGameManager.LocalPlayerColor.Value;
+            PlayerPrefs.SetFloat("UserColor_R", newColor.r);
+            PlayerPrefs.SetFloat("UserColor_G", newColor.g);
+            PlayerPrefs.SetFloat("UserColor_B", newColor.b);
+            PlayerPrefs.SetFloat("UserColor_A", newColor.a);
+            PlayerPrefs.Save();
         }
 
         /// <summary>

--- a/Assets/VRMPAssets/Scripts/Player/PlayerAppearanceMenu.cs
+++ b/Assets/VRMPAssets/Scripts/Player/PlayerAppearanceMenu.cs
@@ -69,8 +69,7 @@ namespace XRMultiplayer
             List<Color> availableColors = new(m_PlayerColors);
             if (availableColors.Remove(XRINetworkGameManager.LocalPlayerColor.Value))
             {
-                XRINetworkGameManager.LocalPlayerColor.Value
-                 = availableColors[Random.Range(0, availableColors.Count)];
+                XRINetworkGameManager.LocalPlayerColor.Value = availableColors[Random.Range(0, availableColors.Count)];
             }
             else
             {

--- a/Assets/VRMPAssets/Scripts/Player/PlayerAppearanceMenu.cs
+++ b/Assets/VRMPAssets/Scripts/Player/PlayerAppearanceMenu.cs
@@ -18,7 +18,6 @@ namespace XRMultiplayer
         [Header("Name Field")]
         [SerializeField] TMP_InputField m_PlayerNameInputField;
 
-        // PlayerPrefs keys
         private const string USER_NAME_KEY = "UserName";
         void Awake()
         {

--- a/Assets/VRMPAssets/Scripts/Player/PlayerAppearanceMenu.cs
+++ b/Assets/VRMPAssets/Scripts/Player/PlayerAppearanceMenu.cs
@@ -6,17 +6,29 @@ using UnityEngine.UI;
 namespace XRMultiplayer
 {
     /// <summary>
-    /// A simple example of how to setup a player appearance menu and utilize the bindable variables.
+    /// A simple example of how to setup a player appearance menu,
+    /// utilize the bindable variables, AND use PlayerPrefs for persistence.
     /// </summary>
     public class PlayerAppearanceMenu : MonoBehaviour
     {
+        [Header("Color Setup")]
         [SerializeField] Color[] m_PlayerColors;
-        [SerializeField] TMP_InputField m_PlayerNameInputField;
         [SerializeField] Image m_PlayerIconColor;
 
+        [Header("Name Field")]
+        [SerializeField] TMP_InputField m_PlayerNameInputField;
+
+        // PlayerPrefs keys
+        private const string USER_NAME_KEY = "UserName";
+        // Example key if an avatar dropdown is added later:
+        private const string AVATAR_INDEX_KEY = "AvatarIndex";
 
         void Awake()
         {
+            string savedName = PlayerPrefs.GetString(USER_NAME_KEY, "Player");
+
+            XRINetworkGameManager.LocalPlayerName.Value = savedName;
+
             XRINetworkGameManager.LocalPlayerName.Subscribe(SetPlayerName);
             XRINetworkGameManager.LocalPlayerColor.Subscribe(SetPlayerColor);
         }
@@ -34,12 +46,16 @@ namespace XRMultiplayer
         }
 
         /// <summary>
-        /// Use this to set the player's name so it triggers the bindable variable
+        /// Called by a Unity UI InputField (OnEndEdit) or a button that passes the field's text.
+        /// This sets the player's name network-wide AND saves it in PlayerPrefs.
         /// </summary>
-        /// <param name="text"></param>
         public void SubmitNewPlayerName(string text)
         {
+            
             XRINetworkGameManager.LocalPlayerName.Value = text;
+
+            PlayerPrefs.SetString(USER_NAME_KEY, text);
+            PlayerPrefs.Save();
         }
 
         /// <summary>
@@ -51,23 +67,33 @@ namespace XRMultiplayer
             List<Color> availableColors = new(m_PlayerColors);
             if (availableColors.Remove(XRINetworkGameManager.LocalPlayerColor.Value))
             {
-
-                XRINetworkGameManager.LocalPlayerColor.Value = availableColors[Random.Range(0, availableColors.Count)];
+                XRINetworkGameManager.LocalPlayerColor.Value 
+                 = availableColors[Random.Range(0, availableColors.Count)];
             }
             else
             {
-                XRINetworkGameManager.LocalPlayerColor.Value = m_PlayerColors[Random.Range(0, m_PlayerColors.Length)];
+                XRINetworkGameManager.LocalPlayerColor.Value 
+                    = m_PlayerColors[Random.Range(0, m_PlayerColors.Length)];
             }
         }
 
+        /// <summary>
+        /// Gets called automatically whenever LocalPlayerName changes.
+        /// Updates the TMP_InputField to show the current name.
+        /// </summary>
         void SetPlayerName(string newName)
         {
             m_PlayerNameInputField.text = newName;
         }
 
+        /// <summary>
+        /// Gets called automatically whenever LocalPlayerColor changes.
+        /// Updates the icon color in your UI.
+        /// </summary>
         void SetPlayerColor(Color color)
         {
             m_PlayerIconColor.color = color;
         }
     }
 }
+

--- a/Assets/VRMPAssets/Scripts/Player/PlayerAppearanceMenu.cs
+++ b/Assets/VRMPAssets/Scripts/Player/PlayerAppearanceMenu.cs
@@ -74,13 +74,6 @@ namespace XRMultiplayer
             {
                 XRINetworkGameManager.LocalPlayerColor.Value = m_PlayerColors[Random.Range(0, m_PlayerColors.Length)];
             }
-            // Code for saving the new color
-            Color newColor = XRINetworkGameManager.LocalPlayerColor.Value;
-            PlayerPrefs.SetFloat("UserColor_R", newColor.r);
-            PlayerPrefs.SetFloat("UserColor_G", newColor.g);
-            PlayerPrefs.SetFloat("UserColor_B", newColor.b);
-            PlayerPrefs.SetFloat("UserColor_A", newColor.a);
-            PlayerPrefs.Save();
         }
 
         /// <summary>
@@ -97,9 +90,15 @@ namespace XRMultiplayer
         /// Updates the icon color in your UI.
         /// </summary>
         void SetPlayerColor(Color color)
-        {
+        {   
             m_PlayerIconColor.color = color;
+            PlayerPrefs.SetFloat("UserColor_R", color.r);
+            PlayerPrefs.SetFloat("UserColor_G", color.g);
+            PlayerPrefs.SetFloat("UserColor_B", color.b);
+            PlayerPrefs.SetFloat("UserColor_A", color.a);
+            PlayerPrefs.Save();
         }
+
     }
 }
 

--- a/Assets/VRMPAssets/Scripts/Player/PlayerNameTag.cs
+++ b/Assets/VRMPAssets/Scripts/Player/PlayerNameTag.cs
@@ -93,8 +93,8 @@ namespace XRMultiplayer
             //Hide name tag if this is the local player
             if (player.IsOwner)
             {
-            m_GameObjectToHide.SetActive(false);
-            return;  // Skip the rest of setup for local player
+                m_GameObjectToHide.SetActive(false);
+                return;  // Skip the rest of setup for local player
             }
             // Only setup the rest for remote players
             UpdateName(player.playerName);

--- a/Assets/VRMPAssets/Scripts/Player/PlayerNameTag.cs
+++ b/Assets/VRMPAssets/Scripts/Player/PlayerNameTag.cs
@@ -91,13 +91,14 @@ namespace XRMultiplayer
             m_Player = player;
             targetTransform = player.head;
 
-            // TODO: Remove comments when we have the name tag feature working
-            // Hide name tag if this is the local player
-            // if (player.IsOwner)
-            // {
+            //TODO: Remove comments when we have the name tag feature working
+            //Hide name tag if this is the local player
+
+            if (player.IsOwner)
+            {
             m_GameObjectToHide.SetActive(false);
             return;  // Skip the rest of setup for local player
-            // }
+            }
 
             // Only setup the rest for remote players
             UpdateName(player.playerName);

--- a/Assets/VRMPAssets/Scripts/Player/PlayerNameTag.cs
+++ b/Assets/VRMPAssets/Scripts/Player/PlayerNameTag.cs
@@ -90,16 +90,12 @@ namespace XRMultiplayer
             m_PlayerId = player.OwnerClientId;
             m_Player = player;
             targetTransform = player.head;
-
-            //TODO: Remove comments when we have the name tag feature working
             //Hide name tag if this is the local player
-
             if (player.IsOwner)
             {
             m_GameObjectToHide.SetActive(false);
             return;  // Skip the rest of setup for local player
             }
-
             // Only setup the rest for remote players
             UpdateName(player.playerName);
             m_ColoredImage.color = m_Player.playerColor;


### PR DESCRIPTION
Overview
This merge request addresses Ticket #9: "Save User's Name and Avatar Preferences." The changes enable local persistence of the user's name using Unity's PlayerPrefs. Now, when a user sets their name, it is saved locally and automatically loaded in subsequent sessions, eliminating the need to reconfigure settings every time the app launches.

Changes Made
PlayerAppearanceMenu.cs
    - Added code to load the saved name from PlayerPrefs (using the key "UserName") with a fallback of "Player" if no name is stored.
    - Sets XRINetworkGameManager.LocalPlayerName.Value to the saved name.
    - Subscribes to the bindable events for name and color as before.
  -SubmitNewPlayerName(): 
    - Modified to update the local bindable variable and then save the new name to PlayerPrefs using "PlayerPrefs.SetString" and "PlayerPrefs.Save()".
  - Declared constant keys for PlayerPrefs ("UserName" and "AvatarIndex" for future extension).

Please review the changes and let me know if any modifications are needed.
